### PR TITLE
Azure complains about not havning a clustered index on the NotFoundRequests table

### DIFF
--- a/src/BVNetwork.404Handler.csproj
+++ b/src/BVNetwork.404Handler.csproj
@@ -233,10 +233,6 @@
       <HintPath>packages\EPiServer.CMS.Core.9.0.0\lib\net45\EPiServer.LinkAnalyzer.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="EPiServer.Logging.Log4Net, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
-      <HintPath>packages\EPiServer.Logging.Log4Net.2.0.0\lib\net45\EPiServer.Logging.Log4Net.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="EPiServer.Shell, Version=9.0.0.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
       <HintPath>packages\EPiServer.Framework.9.0.0\lib\net45\EPiServer.Shell.dll</HintPath>
       <Private>True</Private>
@@ -259,10 +255,6 @@
     </Reference>
     <Reference Include="Ionic.Zip, Version=1.9.1.8, Culture=neutral, PublicKeyToken=edbe51ad942a3f5c, processorArchitecture=MSIL">
       <HintPath>packages\DotNetZip.1.9.1.8\lib\net20\Ionic.Zip.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="log4net, Version=1.2.13.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
-      <HintPath>packages\log4net.2.0.3\lib\net40-full\log4net.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/src/BVNetwork.404Handler.nuspec
+++ b/src/BVNetwork.404Handler.nuspec
@@ -14,9 +14,8 @@
         <summary>The popular 404 handler for EPiServer, enabling better control over your 404 page in addition to allowing redirects for old urls that no longer works.</summary>
         <language>en-US</language>
       <dependencies>
-        <dependency id="EPiServer.CMS.UI.Core" version="9.0.0" />
-        <dependency id="EPiServer.Framework" version="9.0.0" />
-        <dependency id="EPiServer.Logging.Log4Net" version="2.0.0" />
+        <dependency id="EPiServer.CMS.UI.Core" version="[9.0.0, 10.0)" />
+        <dependency id="EPiServer.Framework" version="[9.0.0, 10.0)" />
       </dependencies>
     </metadata>
     <files>

--- a/src/Core/Data/DataAccessBaseEx.cs
+++ b/src/Core/Data/DataAccessBaseEx.cs
@@ -29,26 +29,28 @@ namespace BVNetwork.NotFound.Core.Data
 
             return base.Database.Execute<DataSet>(delegate
             {
-                DataSet ds = new DataSet();
-                try
+                using (DataSet ds = new DataSet())
                 {
-                    DbCommand command = this.CreateCommand(sqlCommand);
-                    if (parameters != null)
+                    try
                     {
-                        foreach (SqlParameter parameter in parameters)
+                        DbCommand command = this.CreateCommand(sqlCommand);
+                        if (parameters != null)
                         {
-                            command.Parameters.Add(parameter);
+                            foreach (SqlParameter parameter in parameters)
+                            {
+                                command.Parameters.Add(parameter);
+                            }
                         }
+                        command.CommandType = CommandType.Text;
+                        base.CreateDataAdapter(command).Fill(ds);
                     }
-                    command.CommandType = CommandType.Text;
-                    base.CreateDataAdapter(command).Fill(ds);
-                }
-                catch (Exception ex)
-                {
-                    Logger.Error(string.Format("An error occureding in the ExecuteSQL method with the following sql{0}. Exception:{1}", sqlCommand, ex));
-                }
+                    catch (Exception ex)
+                    {
+                        Logger.Error(string.Format("An error occureding in the ExecuteSQL method with the following sql{0}. Exception:{1}", sqlCommand, ex));
+                    }
 
-                return ds;
+                    return ds;
+                }
             });
 
         }
@@ -78,6 +80,30 @@ namespace BVNetwork.NotFound.Core.Data
 
         }
 
+        public int ExecuteScalar(string sqlCommand)
+        {
+            return base.Database.Execute<int>(delegate
+            {
+                int result;
+                try
+                {
+                    IDbCommand dbCommand = this.CreateCommand(sqlCommand);
+                    dbCommand.CommandType = CommandType.Text;
+                    result = (int)dbCommand.ExecuteScalar();
+                }
+                catch (Exception ex)
+                {
+                    result = 0;
+                    Logger.Error(
+                        string.Format(
+                            "An error occureding in the ExecuteScalar method with the following sql{0}. Exception:{1}",
+                            sqlCommand,
+                            ex));
+                    
+                }
+                return result;
+            });
+        }
 
         public DataSet GetAllClientRequestCount()
         {

--- a/src/Core/Data/DataStoreEventHandler.cs
+++ b/src/Core/Data/DataStoreEventHandler.cs
@@ -2,13 +2,14 @@
 using BVNetwork.NotFound.Core.CustomRedirects;
 using EPiServer.Events;
 using EPiServer.Events.Clients;
+using EPiServer.Logging;
 
 namespace BVNetwork.NotFound.Core.Data
 {
 
     public class DataStoreEventHandlerHook : EPiServer.PlugIn.PlugInAttribute
     {
-        private static readonly log4net.ILog _log = log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
+        private static readonly ILogger _log = LogManager.GetLogger(typeof(DataStoreEventHandlerHook));
         private static readonly Guid _dataStoreUpdateEventId = new Guid("{26A1CA35-1CBD-44a7-8243-5E80D79F3F26}");
         private static readonly Guid _dataStoreUpdateRaiserId = new Guid("{6180555A-7A0E-4485-B1B1-44BF6E4D4A0D}");
 
@@ -19,9 +20,9 @@ namespace BVNetwork.NotFound.Core.Data
                 if (Event.EventsEnabled)
                 {
 
-                    _log.DebugFormat("Begin: Initializing Data Store Invalidation Handler on '{0}'", Environment.MachineName);
+                    _log.Debug("Begin: Initializing Data Store Invalidation Handler on '{0}'", Environment.MachineName);
 
-                    _log.DebugFormat("Domain ID: '{0}', Friendly Name: '{1}', Basedir: '{2}', Thread: '{3}'",
+                    _log.Debug("Domain ID: '{0}', Friendly Name: '{1}', Basedir: '{2}', Thread: '{3}'",
                         AppDomain.CurrentDomain.Id.ToString(),
                         AppDomain.CurrentDomain.FriendlyName,
                         AppDomain.CurrentDomain.BaseDirectory,
@@ -30,11 +31,11 @@ namespace BVNetwork.NotFound.Core.Data
                     Event dataStoreInvalidationEvent = Event.Get(_dataStoreUpdateEventId);
                     dataStoreInvalidationEvent.Raised += new EventNotificationHandler(dataStoreInvalidationEvent_Raised);
 
-                    _log.DebugFormat("End: Initializing Data Store Invalidation Handler on '{0}'", Environment.MachineName);
+                    _log.Debug("End: Initializing Data Store Invalidation Handler on '{0}'", Environment.MachineName);
 
                 }
                 else
-                    _log.DebugFormat("NOT Initializing Data Store Invalidation Handler on '{0}'. Events are disabled for this site.", Environment.MachineName);
+                    _log.Debug("NOT Initializing Data Store Invalidation Handler on '{0}'. Events are disabled for this site.", Environment.MachineName);
             }
             catch (Exception ex)
             {
@@ -44,10 +45,10 @@ namespace BVNetwork.NotFound.Core.Data
 
         static void dataStoreInvalidationEvent_Raised(object sender, EventNotificationEventArgs e)
         {
-            _log.DebugFormat("dataStoreInvalidationEvent '{2}' handled - raised by '{0}' on '{1}'", e.RaiserId, Environment.MachineName, e.EventId);
-            _log.DebugFormat("Begin: Clearing cache on '{0}'", Environment.MachineName);
+            _log.Debug("dataStoreInvalidationEvent '{2}' handled - raised by '{0}' on '{1}'", e.RaiserId, Environment.MachineName, e.EventId);
+            _log.Debug("Begin: Clearing cache on '{0}'", Environment.MachineName);
             CustomRedirectHandler.ClearCache();
-            _log.DebugFormat("End: Clearing cache on '{0}'", Environment.MachineName);
+            _log.Debug("End: Clearing cache on '{0}'", Environment.MachineName);
             // CustomRedirectHandler handler = CustomRedirectHandler.Current;
 
         }

--- a/src/Core/Initialization/Custom404HandlerInitialization.cs
+++ b/src/Core/Initialization/Custom404HandlerInitialization.cs
@@ -5,7 +5,7 @@ using BVNetwork.NotFound.Core.Data;
 using BVNetwork.NotFound.Core.Upgrade;
 using EPiServer.Framework;
 using EPiServer.Framework.Initialization;
-using log4net;
+using EPiServer.Logging;
 
 namespace BVNetwork.NotFound.Core.Initialization
 {
@@ -16,7 +16,7 @@ namespace BVNetwork.NotFound.Core.Initialization
     [ModuleDependency(typeof(EPiServer.Web.InitializationModule))]
     public class Custom404HandlerInitialization : IInitializableHttpModule
     {
-        private static readonly ILog _log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+        private static readonly ILogger _log = LogManager.GetLogger(typeof(Custom404HandlerInitialization));
 
         public void Initialize(InitializationEngine context)
         {

--- a/src/Core/NotFoundPage/NotFoundBase.cs
+++ b/src/Core/NotFoundPage/NotFoundBase.cs
@@ -1,13 +1,15 @@
 using System;
 using System.Web;
 using BVNetwork.FileNotFound;
+
+using EPiServer.Logging;
 using EPiServer.Web;
 
 namespace BVNetwork.NotFound.Core.NotFoundPage
 {
     public class NotFoundBase : System.Web.UI.Page
     {
-        private static readonly log4net.ILog _log = log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
+        private static readonly ILogger _log = LogManager.GetLogger(typeof(NotFoundBase));
 
         private Uri _urlNotFound = null;
         private string _referer = null;

--- a/src/Core/NotFoundPage/NotFoundPageUtil.cs
+++ b/src/Core/NotFoundPage/NotFoundPageUtil.cs
@@ -1,13 +1,14 @@
 using System;
 using System.Web;
 using EPiServer;
+using EPiServer.Logging;
 using EPiServer.Web;
 
 namespace BVNetwork.NotFound.Core.NotFoundPage
 {
     public static class NotFoundPageUtil
     {
-        private static readonly log4net.ILog _log = log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
+        private static readonly ILogger _log = LogManager.GetLogger(typeof(NotFoundPageUtil));
 
         /// <summary>
         /// Gets the content for the 404 page from the language files.

--- a/src/Core/Upgrade/Upgrader.cs
+++ b/src/Core/Upgrade/Upgrader.cs
@@ -2,13 +2,14 @@
 using System.Linq;
 using BVNetwork.NotFound.Core.CustomRedirects;
 using BVNetwork.NotFound.Core.Data;
-using log4net;
+
+using EPiServer.Logging;
 
 namespace BVNetwork.NotFound.Core.Upgrade
 {
     public static class Upgrader
     {
-        private static readonly ILog _log = LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
+        private static readonly ILogger _log = LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
 
         public static bool Valid { get; set; }
 
@@ -32,7 +33,7 @@ namespace BVNetwork.NotFound.Core.Upgrade
 
             var dba = DataAccessBaseEx.GetWorker();
 
-            _log.Info("Create 404 handler redirects table START");
+            _log.Information("Create 404 handler redirects table START");
             string createTableScript = @"CREATE TABLE [dbo].[BVN.NotFoundRequests](
 	                                    [ID] [int] IDENTITY(1,1) NOT NULL,
 	                                    [OldUrl] [nvarchar](2000) NOT NULL,
@@ -41,12 +42,12 @@ namespace BVNetwork.NotFound.Core.Upgrade
                                         ) ON [PRIMARY]";
             create = dba.ExecuteNonQuery(createTableScript);
 
-            _log.Info("Create 404 handler redirects table END");
+            _log.Information("Create 404 handler redirects table END");
 
 
             if (create)
             {
-                _log.Info("Create 404 handler version SP START");
+                _log.Information("Create 404 handler version SP START");
                 string versionSP = @"CREATE PROCEDURE [dbo].[bvn_notfoundversion] AS RETURN " + Configuration.Configuration.CURRENT_VERSION;
 
                 if (!dba.ExecuteNonQuery(versionSP))
@@ -55,12 +56,12 @@ namespace BVNetwork.NotFound.Core.Upgrade
                     _log.Error("An error occured during the creation of the 404 handler version stored procedure. Canceling.");
                 }
 
-                _log.Info("Create 404 handler version SP END");
+                _log.Information("Create 404 handler version SP END");
             }
 
             if (create)
             {
-                _log.Info("Create Clustered index START");
+                _log.Information("Create Clustered index START");
                 string clusteredIndex =
                     "CREATE CLUSTERED INDEX NotFoundRequests_ID ON [dbo].[BVN.NotFoundRequests] (ID)";
 
@@ -70,7 +71,7 @@ namespace BVNetwork.NotFound.Core.Upgrade
                     _log.Error("An error occurred during the creation of the 404 handler redirects clustered index. Canceling.");
                 }
 
-                _log.Info("Create Clustered index END");
+                _log.Information("Create Clustered index END");
             }
 
             Valid = create;
@@ -116,7 +117,7 @@ namespace BVNetwork.NotFound.Core.Upgrade
                     Valid = false;
                     _log.Error("An error occurred during the creation of the 404 handler redirects clustered index. Canceling.");
                 }
-                _log.Info("Create Clustered index END");
+                _log.Information("Create Clustered index END");
             }
             if (Valid)
             {

--- a/src/packages.config
+++ b/src/packages.config
@@ -1,16 +1,16 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Castle.Core" version="3.2.0" targetFramework="net45" />
-  <package id="Castle.Windsor" version="3.2.0" targetFramework="net45" />
-  <package id="DotNetZip" version="1.9.1.8" targetFramework="net45" />
-  <package id="EPiServer.CMS.Core" version="9.0.0" targetFramework="net45" />
-  <package id="EPiServer.CMS.UI.Core" version="9.0.0" targetFramework="net45" />
-  <package id="EPiServer.Framework" version="9.0.0" targetFramework="net45" />
-  <package id="Microsoft.AspNet.Mvc" version="4.0.20710.0" targetFramework="net45" />
-  <package id="Microsoft.AspNet.Razor" version="2.0.20710.0" targetFramework="net45" />
-  <package id="Microsoft.AspNet.WebPages" version="2.0.20710.0" targetFramework="net45" />
-  <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="5.0.8" targetFramework="net45" />
-  <package id="structuremap-signed" version="3.1.6.186" targetFramework="net45" />
-  <package id="structuremap.web-signed" version="3.1.6.186" targetFramework="net45" />
+  <package id="Castle.Core" version="3.2.0" targetFramework="net45" developmentDependency="true" />
+  <package id="Castle.Windsor" version="3.2.0" targetFramework="net45" developmentDependency="true" />
+  <package id="DotNetZip" version="1.9.1.8" targetFramework="net45" developmentDependency="true" />
+  <package id="EPiServer.CMS.Core" version="9.0.0" targetFramework="net45"  developmentDependency="true"/>
+  <package id="EPiServer.CMS.UI.Core" version="9.0.0" targetFramework="net45" developmentDependency="true" />
+  <package id="EPiServer.Framework" version="9.0.0" targetFramework="net45" developmentDependency="true" />
+  <package id="Microsoft.AspNet.Mvc" version="4.0.20710.0" targetFramework="net45" developmentDependency="true" />
+  <package id="Microsoft.AspNet.Razor" version="2.0.20710.0" targetFramework="net45" developmentDependency="true" />
+  <package id="Microsoft.AspNet.WebPages" version="2.0.20710.0" targetFramework="net45" developmentDependency="true" />
+  <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net45" developmentDependency="true" />
+  <package id="Newtonsoft.Json" version="5.0.8" targetFramework="net45" developmentDependency="true" />
+  <package id="structuremap-signed" version="3.1.6.186" targetFramework="net45" developmentDependency="true" />
+  <package id="structuremap.web-signed" version="3.1.6.186" targetFramework="net45" developmentDependency="true" />
 </packages>

--- a/src/packages.config
+++ b/src/packages.config
@@ -6,8 +6,6 @@
   <package id="EPiServer.CMS.Core" version="9.0.0" targetFramework="net45" />
   <package id="EPiServer.CMS.UI.Core" version="9.0.0" targetFramework="net45" />
   <package id="EPiServer.Framework" version="9.0.0" targetFramework="net45" />
-  <package id="EPiServer.Logging.Log4Net" version="2.0.0" targetFramework="net45" />
-  <package id="log4net" version="2.0.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.Mvc" version="4.0.20710.0" targetFramework="net45" />
   <package id="Microsoft.AspNet.Razor" version="2.0.20710.0" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebPages" version="2.0.20710.0" targetFramework="net45" />


### PR DESCRIPTION
Added ExexuteScalar to DB layer.
Added clustered index to NotFoundRequests table, Azure complains about not having one.

Added using to DataSet, performance warning in CA.

I did these changes on an older version, before GitHub. So please double check.