### PR TITLE
allow case sensetive urls

### DIFF
--- a/src/Core/CustomRedirects/CustomRedirect.cs
+++ b/src/Core/CustomRedirects/CustomRedirect.cs
@@ -40,7 +40,7 @@ namespace BVNetwork.NotFound.Core.CustomRedirects
 		{
 			get
 			{
-				return _oldUrl;
+				return _oldUrl.ToLower(); 
 			}
 			set
 			{

--- a/src/Core/CustomRedirects/CustomRedirect.cs
+++ b/src/Core/CustomRedirects/CustomRedirect.cs
@@ -40,7 +40,7 @@ namespace BVNetwork.NotFound.Core.CustomRedirects
 		{
 			get
 			{
-				return _oldUrl.ToLower();
+				return _oldUrl;
 			}
 			set
 			{
@@ -53,7 +53,7 @@ namespace BVNetwork.NotFound.Core.CustomRedirects
 			get
 			{
                
-				return  _newUrl != null ? _newUrl.ToLower() : null;
+				return  _newUrl != null ? _newUrl : null;
 			}
 			set
 			{

--- a/src/Core/Data/DataStoreHandler.cs
+++ b/src/Core/Data/DataStoreHandler.cs
@@ -95,7 +95,7 @@ namespace BVNetwork.NotFound.Core.Data
             DynamicDataStore store = DataStoreFactory.GetStore(typeof(CustomRedirect));
 
             //find object with matching property "OldUrl"
-            CustomRedirect match = store.Find<CustomRedirect>(OLD_URL_PROPERTY_NAME, oldUrl).SingleOrDefault();
+            CustomRedirect match = store.Find<CustomRedirect>(OLD_URL_PROPERTY_NAME, oldUrl.ToLower()).SingleOrDefault();
             if (match != null)
                 store.Delete(match);
         }

--- a/src/Core/Data/DataStoreHandler.cs
+++ b/src/Core/Data/DataStoreHandler.cs
@@ -22,7 +22,7 @@ namespace BVNetwork.NotFound.Core.Data
             // Get hold of the datastore
             DynamicDataStore store = DataStoreFactory.GetStore(typeof(CustomRedirect));
             //check if there is an exisiting object with matching property "OldUrl"
-            CustomRedirect match = store.Find<CustomRedirect>(OLD_URL_PROPERTY_NAME, currentCustomRedirect.OldUrl.ToLower()).SingleOrDefault();
+            CustomRedirect match = store.Find<CustomRedirect>(OLD_URL_PROPERTY_NAME, currentCustomRedirect.OldUrl).SingleOrDefault();
             //if there is a match, replace the value.
             if (match != null)
                 store.Save(currentCustomRedirect, match.Id);

--- a/src/Core/Data/DataStoreHandler.cs
+++ b/src/Core/Data/DataStoreHandler.cs
@@ -95,7 +95,7 @@ namespace BVNetwork.NotFound.Core.Data
             DynamicDataStore store = DataStoreFactory.GetStore(typeof(CustomRedirect));
 
             //find object with matching property "OldUrl"
-            CustomRedirect match = store.Find<CustomRedirect>(OLD_URL_PROPERTY_NAME, oldUrl.ToLower()).SingleOrDefault();
+            CustomRedirect match = store.Find<CustomRedirect>(OLD_URL_PROPERTY_NAME, oldUrl).SingleOrDefault();
             if (match != null)
                 store.Delete(match);
         }

--- a/src/Core/Data/DataStoreHandler.cs
+++ b/src/Core/Data/DataStoreHandler.cs
@@ -22,7 +22,7 @@ namespace BVNetwork.NotFound.Core.Data
             // Get hold of the datastore
             DynamicDataStore store = DataStoreFactory.GetStore(typeof(CustomRedirect));
             //check if there is an exisiting object with matching property "OldUrl"
-            CustomRedirect match = store.Find<CustomRedirect>(OLD_URL_PROPERTY_NAME, currentCustomRedirect.OldUrl).SingleOrDefault();
+            CustomRedirect match = store.Find<CustomRedirect>(OLD_URL_PROPERTY_NAME, currentCustomRedirect.OldUrl.ToLower()).SingleOrDefault();
             //if there is a match, replace the value.
             if (match != null)
                 store.Save(currentCustomRedirect, match.Id);

--- a/src/Core/Obsolete/CustomRedirect.cs
+++ b/src/Core/Obsolete/CustomRedirect.cs
@@ -40,7 +40,7 @@ namespace BVNetwork.FileNotFound.CustomRedirects
         {
             get
             {
-                return _oldUrl.ToLower();
+                return _oldUrl;
             }
             set
             {
@@ -52,7 +52,7 @@ namespace BVNetwork.FileNotFound.CustomRedirects
         {
             get
             {
-                return _newUrl.ToLower();
+                return _newUrl;
             }
             set
             {

--- a/src/Core/Obsolete/CustomRedirect.cs
+++ b/src/Core/Obsolete/CustomRedirect.cs
@@ -40,7 +40,7 @@ namespace BVNetwork.FileNotFound.CustomRedirects
         {
             get
             {
-                return _oldUrl;
+                return _oldUrl.ToLower(); 
             }
             set
             {


### PR DESCRIPTION
Cannot do redirect to case sensetive urls. Since they get tolowered.

i.e. trying to do a redirect from: /downloads 
to: /foobar?currentTab=FreeTrials 
gets redirected to /foobar?currenttab=freetrials